### PR TITLE
Fix setup.py on non UTF-8 system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,23 @@
 from setuptools import setup
 
 import first
+import sys
+
+
+if sys.version_info[0] >= 3:
+    openf = open
+else:
+    import codecs
+    openf = codecs.open
 
 
 setup(
     name='first',
     version=first.__version__,
     description='Return the first true value of an iterable.',
-    long_description=(open('README.rst').read() + '\n\n' +
-                      open('HISTORY.rst').read() + '\n\n' +
-                      open('AUTHORS.rst').read()),
+    long_description=(openf('README.rst', encoding='utf-8').read() + '\n\n' +
+                      openf('HISTORY.rst', encoding='utf-8').read() + '\n\n' +
+                      openf('AUTHORS.rst', encoding='utf-8').read()),
     url='http://github.com/hynek/first/',
     license=first.__license__,
     author=first.__author__,


### PR DESCRIPTION
Python 3 isn't able to decode the rst files if no encoding is specified and
if the environment is not UTF-8 compatible by default.
This fixes that.
