### PR TITLE
Add dictionary support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ first.egg-info
 .coverage
 .cache
 .tox
+venv/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ first.egg-info
 .cache
 .tox
 venv/
+.idea/

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,6 +4,7 @@ Credits
 “first” is written and maintained by Hynek Schlawack and various contributors:
 
 - Artem Bezsmertnyi
+- Charles Ross
 - Łukasz Langa
 - Nick Coghlan
 - Vincent Driessen

--- a/first.py
+++ b/first.py
@@ -1,4 +1,4 @@
-## -*- coding: utf-8 -*-
+# -*- coding: utf-8 -*-
 
 """
 first
@@ -58,6 +58,9 @@ def first(iterable, default=None, key=None):
     >>> m.group(1)
     'bc'
 
+    >>> first({1: 3.14, 2: 2.72, 3: None})
+    3
+
     The optional `key` argument specifies a one-argument predicate function
     like that used for `filter()`.  The `key` argument, if supplied, must be
     in keyword form.  For example:
@@ -66,13 +69,24 @@ def first(iterable, default=None, key=None):
     4
 
     """
-    if key is None:
-        for el in iterable:
-            if el:
-                return el
+    if isinstance(iterable, dict):
+        if key is None:
+            for el, v in iterable.items():
+                if v:
+                    return el
+        else:
+            for el, v in iterable.items():
+                if key(v):
+                    return el
+
     else:
-        for el in iterable:
-            if key(el):
-                return el
+        if key is None:
+            for el in iterable:
+                if el:
+                    return el
+        else:
+            for el in iterable:
+                if key(el):
+                    return el
 
     return default

--- a/first.py
+++ b/first.py
@@ -58,8 +58,8 @@ def first(iterable, default=None, key=None):
     >>> m.group(1)
     'bc'
 
-    >>> first({1: 3.14, 2: 2.72, 3: None})
-    3
+    >>> first({1: None, 2: 3.14, 3: 2.72})
+    2
 
     The optional `key` argument specifies a one-argument predicate function
     like that used for `filter()`.  The `key` argument, if supplied, must be

--- a/first.py
+++ b/first.py
@@ -68,6 +68,12 @@ def first(iterable, default=None, key=None):
     >>> first([1, 1, 3, 4, 5], key=lambda x: x % 2 == 0)
     4
 
+    When using key with a dictionary iterable, the key applies to the values
+    in the dictionary.
+
+    >>> first({1: None, 2: 3.14, 3: 2.72}, key=lambda x: x is None)
+    1
+
     """
     if isinstance(iterable, dict):
         if key is None:

--- a/test_first.py
+++ b/test_first.py
@@ -53,6 +53,10 @@ class TestFirst(unittest.TestCase):
         assert first(d, key=even) == 2
         assert first(d, key=is_meaning_of_life) is None
 
+        d = {1: None, 2: 3.14, 3: 2.72}
+
+        assert first(d) == 2
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_first.py
+++ b/test_first.py
@@ -35,6 +35,24 @@ class TestFirst(unittest.TestCase):
         assert first(l, key=even) == 0
         assert first(l, key=is_meaning_of_life) is None
 
+    def test_dictionary_first(self):
+        d = {
+                1: (),
+                2: 0,
+                3: False,
+                4: 3,
+                5: [],
+                6: None
+        }
+
+        assert first(d) == 4
+        assert first(d, default=42) == 4
+        assert first(d, key=isint) == 2
+        assert first(d, key=isbool) == 3
+        assert first(d, key=odd) == 4
+        assert first(d, key=even) == 2
+        assert first(d, key=is_meaning_of_life) is None
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_first.py
+++ b/test_first.py
@@ -56,6 +56,7 @@ class TestFirst(unittest.TestCase):
         d = {1: None, 2: 3.14, 3: 2.72}
 
         assert first(d) == 2
+        assert first(d, key=lambda x: not x) == 1
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add the ability for first to test against dictionary values and return the corresponding key.

Here's the story behind why I wanted this (and perhaps others do too).

I had this line of code in a project I'm working on:

    question_id = [int(id) for id in question_ids if json_answers[id] is None][0]

It worked but seemed difficult to understand. I heard about `first` and after installing it, changed the line to:

    question_id = int(first(json_answers.keys(), key=lambda x:json_answers[x] == None))

I think reading that is easier to understand the intent, but thought it would be nice if I could just pass `json_answers` to `first` and have it use the values for the comparisons. With the change I made to it, the line has become

    question_id = int(first(json_answers), key=lambda x:x is None)

So, just in case you like the change, here it is. If you don't want to include it, I'd like to hear why. I'm a long-time programmer, but this is my first Python project longer than a single script, and any feedback would help me learn.